### PR TITLE
prefix private methods

### DIFF
--- a/rover/roboclaw.py
+++ b/rover/roboclaw.py
@@ -107,11 +107,11 @@ class Roboclaw:
 		FLAGBOOTLOADER = 255
 			
 	#Private Functions
-	def crc_clear(self):
+	def _crc_clear(self):
 		self._crc = 0
 		return
 		
-	def crc_update(self,data):
+	def _crc_update(self, data):
 		self._crc = self._crc ^ (data << 8)
 		for bit in range(0, 8):
 			if (self._crc&0x8000)  == 0x8000:
@@ -121,10 +121,10 @@ class Roboclaw:
 		return
 
 	def _sendcommand(self,address,command):
-		self.crc_clear()
-		self.crc_update(address)
+		self._crc_clear()
+		self._crc_update(address)
 		self._port.write(chr(address))
-		self.crc_update(command)
+		self._crc_update(command)
 		self._port.write(chr(command))
 		return
 
@@ -139,7 +139,7 @@ class Roboclaw:
 		data = self._port.read(1)
 		if len(data):
 			val = ord(data)
-			self.crc_update(val)
+			self._crc_update(val)
 			return (1,val)	
 		return (0,0)
 		
@@ -172,7 +172,7 @@ class Roboclaw:
 		return (0,0)
 
 	def _writebyte(self,val):
-		self.crc_update(val&0xFF)
+		self._crc_update(val & 0xFF)
 		self._port.write(chr(val&0xFF))
 
 	def _writesbyte(self,val):
@@ -711,7 +711,7 @@ class Roboclaw:
 				data = self._port.read(1)
 				if len(data):
 					val = ord(data)
-					self.crc_update(val)
+					self._crc_update(val)
 					if(val==0):
 						break
 					str+=data[0]


### PR DESCRIPTION
I believe these functions should have been private due to the comment preceding them and due to the fact that they are only used locally. There is another section in the code for public functions, so perhaps they were originally intended to be public but I doubt that due the naming scheme and their utility. (See issue #3 which I created earlier)

_I did not run the code since I did not actually built the rover (..yet?)_

