### PR TITLE
Simple contributing guide added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # JPL's Open Source Rover Control Code
 This repository houses the source code for the controller for JPL's Open Source Rover.  Please see the Open Source Rover's [main repository](https://github.com/nasa-jpl/open-source-rover) for instructions on how to obtain and use the contents of this repository.
+
+
+## Contributing
+
+1. Read https://code.nasa.gov/#/guide
+2. Fork it 
+3. Create your feature branch (`git checkout -b your-name/issue-number-feature`)
+4. Commit your changes (`git commit -am 'Add some logarithms'`)
+5. Push to the branch (`git push origin feature/logarithms`)
+6. Create a new Pull Request

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This repository houses the source code for the controller for JPL's Open Source 
 ## Contributing
 
 1. Read https://code.nasa.gov/#/guide
-2. Fork it 
-3. Create your feature branch (`git checkout -b your-name/issue-number-feature`)
-4. Commit your changes (`git commit -am 'Add some logarithms'`)
-5. Push to the branch (`git push origin feature/logarithms`)
-6. Create a new Pull Request
+2. Open an issue on this repo and explain what you plan to contribute. This helps avoid duplicate efforts.
+3. Fork it.
+4. Create your feature branch (`git checkout -b your-name/issue-number-feature`)
+5. Commit your changes (`git commit -m 'Add some feature'`)
+6. Push to the branch (`git push origin branch-name`)
+7. Create a new Pull Request.


### PR DESCRIPTION
Per issue #9 :

```Add a CONTRIBUTING.md - helps promote best practices for working on an issue or submitting a PR, sometimes occompanied by a code of conduct. (This one's also still on my backlog of things to do)```

NASA has a website with contributing info (https://code.nasa.gov/#/guide), but I'm not sure if it applies here given that this is a caltech project at heart. @asasine What do you think?