### PR TITLE
Add travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+python:
+  - "3.4"
+  - "3.5"
+  - "3.5-dev"  # 3.5 development branch
+  - "3.6"
+  - "3.6-dev"  # 3.6 development branch
+  # - "3.7-dev"  # 3.7 development branch
+install:
+  - pip install --upgrade pip
+  # - pip install coverage
+  # - pip install python-coveralls
+  - pip install pytest
+  # - pip install pytest-cov
+  - pip install pytest-pep8
+  - pip install -r requirements.txt
+script:
+  # - python setup.y install
+  - pytest -vv --pep8 # --cov-report term-missing --cov=rover
+# after_success:
+#   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
   - "3.6"
   - "3.6-dev"  # 3.6 development branch
   # - "3.7-dev"  # 3.7 development branch
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install bluetooth libbluetooth-dev python-dev
 install:
   - pip install --upgrade pip
   # - pip install coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # JPL's Open Source Rover Control Code
 This repository houses the source code for the controller for JPL's Open Source Rover.  Please see the Open Source Rover's [main repository](https://github.com/nasa-jpl/open-source-rover) for instructions on how to obtain and use the contents of this repository.
 
+[![Build Status](https://travis-ci.com/nasa-jpl/osr-rover-code.svg?branch=master)](https://travis-ci.com/nasa-jpl/osr-rover-code)
+
 # Installing
 
 Make sure to read the install instructions on the main rover repo: https://github.com/nasa-jpl/open-source-rover/blob/master/Software/Software%20Steps.pdf

--- a/README.md
+++ b/README.md
@@ -17,4 +17,3 @@ Specifically section `1.2.1`
 5. Commit your changes (`git commit -m 'Add some feature'`)
 6. Push to the branch (`git push origin branch-name`)
 7. Create a new Pull Request.
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # JPL's Open Source Rover Control Code
 This repository houses the source code for the controller for JPL's Open Source Rover.  Please see the Open Source Rover's [main repository](https://github.com/nasa-jpl/open-source-rover) for instructions on how to obtain and use the contents of this repository.
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Build Status](https://travis-ci.com/nasa-jpl/osr-rover-code.svg?branch=master)](https://travis-ci.com/nasa-jpl/osr-rover-code)
 
 # Installing


### PR DESCRIPTION
Closes #14 

Additional notes: 
 - Added badges for Apache license and build status in README.md
 - Install and after_scripts for coverage are also included, but commented out, in `.travis.yml`. A project maintainer will need to go to a code coverage hosting site (s.a., [coveralls.io](https://coveralls.io)) and enable code coverage for this repo, along side adding unit tests (#12), if they wish to use this feature.
 - I'm getting import errors in my vs code editor for the `bluetooth` module. Let me know if anyone else has this issue. It's possible I may've missed a dependency.
 - ~Started to clean linting issues & migrate to python3 (in response to #5) in https://github.com/nasa-jpl/osr-rover-code/commit/941caed663728adba20226d56078cd710e2edae5. Changes for python3 only consist of `print()` statements at the moment. There are still a lot of linting issues remaining, so the build badge will most likely display "failing" if you decide to merge as of now (see associated [build](https://travis-ci.com/capsulecorplab/osr-rover-code/builds/87707782) log).~