### PR TITLE
Fixes for issues in Init Scripts

### DIFF
--- a/Init Scripts/LaunchOSR.sh
+++ b/Init Scripts/LaunchOSR.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-bash -c ". /home/pi/osr_ws/devel/setup.sh"
-bash -c ". /home/pi/osr_ws/devel/setup.bash"
+bash -c ". /home/ubuntu/osr_ws/devel/setup.sh"
+bash -c ". /home/ubuntu/osr_ws/devel/setup.bash"
 bash -c ". /opt/ros/kinetic/setup.sh"
 bash -c ". /opt/ros/kinetic/setup.bash"
 bash -i -c "roslaunch osr_bringup osr.launch"

--- a/Init Scripts/osr_startup.service
+++ b/Init Scripts/osr_startup.service
@@ -5,12 +5,12 @@ After=network.target
 [Service]
 User=ubuntu
 Group=ubuntu
-WorkingDirectory=/home/ubuntu/LaunchOSR.sh
-ExecStart=/home/ubuntu/
+WorkingDirectory=/home/ubuntu
+ExecStart=/usr/bin/LaunchOSR.sh
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 
 RestartSec=3
 
 [Install]
-Wantedby=multi-user.target
+WantedBy=multi-user.target


### PR DESCRIPTION
LaunchOSR.sh and osr_startup.service were at odds - one assumed a user directory of "ubuntu" while the other assumed one of "pi".  I brought them into agreement on ubuntu, but it could just as easily be pi by default.  Ideally, this would be externalized to an environment variable or something.

In osr_startup.service, the WorkingDirectory and ExecStart arguments were swapped.  There was a typo in the case of WantedBy which was also causing issues.