### PR TITLE
Use the ROS param iso hardcoded value in roboclaw_wrapper

### DIFF
--- a/ROS/osr/scripts/roboclaw_wrapper.py
+++ b/ROS/osr/scripts/roboclaw_wrapper.py
@@ -23,9 +23,8 @@ class MotorControllers(object):
 		#					config['CONTROLLER_CONFIG']['baud_rate']
 		#					)
 		rospy.loginfo( "Initializing motor controllers")
-		#self.rc = Roboclaw( rospy.get_param('motor_controller_device', "/dev/serial0"),
-		#					rospy.get_param('baud_rate', 115200))
-		self.rc = Roboclaw("/dev/ttyAMA0",115200)
+		self.rc = Roboclaw(rospy.get_param('motor_controller_device', "/dev/serial0"),
+				   rospy.get_param('baud_rate', 115200))
 		self.rc.Open()
 		self.accel           = [0]    * 10
 		self.qpps            = [None] * 10


### PR DESCRIPTION
## Description

Not sure why this was hardcoded as the rosparam line was commented out right above it. Giving users an indication of the existence of this rosparam in the launch file but then defaulting to the hardcoded value is a big potential source of errors. This change doesn't affect functionality in any way.

## Dependencies

None