### PR TITLE
Add missing python-serial dependency to package.xml for future rosdep/apt install

### DIFF
--- a/ROS/osr/package.xml
+++ b/ROS/osr/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>python-serial</exec_depend>
   <depend>osr_msgs</depend>
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
## Description

It's good practice to track dependencies in package.xml. That way installation can be simplified to [rosdep install](http://wiki.ros.org/rosdep) or even releasing the package to `apt` in the future.

## Dependencies

None