### PR TITLE
Updating to individual dynamic encoder ticks per rev on corner motors

### DIFF
--- a/ROS/osr_bringup/config/roboclaw_params.yaml
+++ b/ROS/osr_bringup/config/roboclaw_params.yaml
@@ -36,20 +36,16 @@ roboclaw_mapping:
   corner_left_front:
     address: 132
     channel: M2
-    ticks_per_rev: 2000
     gear_ratio: 0.3333
   corner_left_back:
     address: 132
     channel: M1
-    ticks_per_rev: 2000
     gear_ratio: 0.3333
   corner_right_back:
     address: 131
     channel: M2
-    ticks_per_rev: 2000
     gear_ratio: 0.3333
   corner_right_front:
     address: 131
     channel: M1
-    ticks_per_rev: 2000
     gear_ratio: 0.3333


### PR DESCRIPTION
Updating corner encoder ticks per rev to be dynamically calculated from motor controller calibration window

Closes #73 