### PR TITLE
Use teleop_twist_joy instead of joystick.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ This branch is an in-development version of the Open Source Rover Code. It conta
 ### Installing
 To install and run the updated software in this branch, please follow the instructions in the [Software Steps.pdf document in the master repository](https://github.com/nasa-jpl/open-source-rover/blob/master/Software/Software%20Steps.pdf).
 
+Then, install the requirements for each package by navigating to the catkin workspace you just made
+and runnning
+
+```
+cd ~/your_catkin_ws/
+rosdep install --from-paths src --ignore-src
+```
+
 <img src="img/OSR_ROS_Diagram.png" width="100%">
 
 ### Catkin Packages

--- a/ROS/osr/CMakeLists.txt
+++ b/ROS/osr/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
   std_msgs
+  geometry_msgs
   sensor_msgs
   osr_msgs
 )

--- a/ROS/osr/package.xml
+++ b/ROS/osr/package.xml
@@ -22,6 +22,7 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>python-serial</exec_depend>
+  <exec_depend>teleop_twist_joy</exec_depend>
   <depend>osr_msgs</depend>
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/ROS/osr/src/joystick.py
+++ b/ROS/osr/src/joystick.py
@@ -103,7 +103,7 @@ def cartesian2polar_45(x,y):
 def two_joy(x,y,rt):
     max_vel = 0.3
     forward_vel = y**3 * max_vel
-    rotation = x * math.pi / 4
+    rotation = x**3 * math.pi / 4
 
     return forward_vel, rotation
 

--- a/ROS/osr/src/joystick.py
+++ b/ROS/osr/src/joystick.py
@@ -2,7 +2,7 @@
 import rospy
 import time
 from sensor_msgs.msg import Joy
-from osr_msgs.msg import Joystick
+from geometry_msgs.msg import Twist
 from std_msgs.msg import Int64MultiArray
 import math
 
@@ -13,115 +13,108 @@ mode,counter = 0,0
 last = time.time()
 
 def callback(data):
-	global mode
-	global counter
-	global last
+    global mode
+    global counter
+    global last
 
-	led_msg = Int64MultiArray()
-	joy_out = Joystick()
+    led_msg = Int64MultiArray()
 
-	y =  data.axes[1]
-	x = -data.axes[0]
-	x1 =-data.axes[3]
-	rt = data.axes[2]
+    y =  data.axes[1]
+    x = -data.axes[0]
+    x1 =-data.axes[3]
+    rt = data.axes[2]
 
-	cmd = two_joy(x1,y,rt)
+    dpad = data.buttons[11:]
+    if 1 in dpad: mode = dpad.index(1)
+    now = time.time()
 
-	dpad = data.buttons[11:]
-	if 1 in dpad: mode = dpad.index(1)
-	now = time.time()
+    led_msg.data = [mode,1]
+    if now - last > 0.75:
+        counter +=1
+    else:
+        counter = 0
+    if counter > 3:
+        led_msg.data = [mode,0]
 
-	led_msg.data = [mode,1]
-	if now - last > 0.75:
-		counter +=1
-	else:
-		counter = 0
-	if counter > 3:
-		led_msg.data = [mode,0]
-
-	last = time.time()
-	led_pub.publish(led_msg)
-	#cmd = cartesian2polar_45(x,y)
-	cmd = two_joy(x1,y,rt)
-	joy_out = Joystick()
-	joy_out.vel = cmd[0]
-	joy_out.steering = cmd[1]
-	joy_out.mode = mode
-	joy_out.connected = True
-	pub.publish(joy_out)
+    last = time.time()
+    led_pub.publish(led_msg)
+    #cmd = cartesian2polar_45(x,y)
+    cmd = two_joy(x1,y,rt)
+    joy_out = Twist()
+    joy_out.linear.x = cmd[0]
+    joy_out.angular.z = cmd[1]
+    pub.publish(joy_out)
 
 def old(x,y):
-	if y < 0: direction = -1
-	else: direction = 1
+    if y < 0: direction = -1
+    else: direction = 1
 
-	r = int(100*math.sqrt(x*x + y*y)) * direction
+    r = int(100*math.sqrt(x*x + y*y)) * direction
 
-	if r > 100: r = 100
-	elif r < -100: r = -100
+    if r > 100: r = 100
+    elif r < -100: r = -100
 
-	if -15 <= r <= 15:
-		r = 0
-		theta = 0
-	#there is some small issue where every once and a while the steering
-	#goes to max negative for one or two values at very small values of y
-	#this eventually needs to be fixed
-	elif -0.01 <= y <= 0.01:
-		theta = 100 * direction
-	else:
-		try:
-			theta = int(math.degrees(math.atan(x/y)) * direction * (10/9.0))
-		except:
-			theta = 0
-	return r,theta
+    if -15 <= r <= 15:
+        r = 0
+        theta = 0
+    #there is some small issue where every once and a while the steering
+    #goes to max negative for one or two values at very small values of y
+    #this eventually needs to be fixed
+    elif -0.01 <= y <= 0.01:
+        theta = 100 * direction
+    else:
+        try:
+            theta = int(math.degrees(math.atan(x/y)) * direction * (10/9.0))
+        except:
+            theta = 0
+    return r,theta
 
 def cartesian2polar_45(x,y):
-	if y < 0: direction = -1
-	else: direction = 1
+    if y < 0: direction = -1
+    else: direction = 1
 
-	r = math.sqrt(x*x + y*y)
-	r = min(r,1.0)
-	try:
-		theta = math.degrees(math.atan2(x,y))
-	except:
-		if x >0: theta = 90
-		else: theta = -90
-	if (-45 <= theta <= 45) or (135 <=theta <= 180) or (-180 <=theta <= -135):
-		vel = int(r * 100) * direction
-	else:
-		vel = (2.0/math.sqrt(2))*y*100
-	vel = min(100,vel)
-	vel = max(-100,vel)
+    r = math.sqrt(x*x + y*y)
+    r = min(r,1.0)
+    try:
+        theta = math.degrees(math.atan2(x,y))
+    except:
+        if x >0: theta = 90
+        else: theta = -90
+    if (-45 <= theta <= 45) or (135 <=theta <= 180) or (-180 <=theta <= -135):
+        vel = int(r * 100) * direction
+    else:
+        vel = (2.0/math.sqrt(2))*y*100
+    vel = min(100,vel)
+    vel = max(-100,vel)
 
-	'''
-	if y >= 0:
-		steering = theta * 10/9.0
-	else:
-		if x >= 0: x_dir = 1
-		else: x_dir = -1
-		steering = (180 - abs(theta)) * (10/9.0) * x_dir
-	'''
-	steering = x * 2.0/math.sqrt(2) * 100
-	steering = min(100,steering)
-	steering = max(-100,steering)
-	return (int(vel),int(steering))
+    '''
+    if y >= 0:
+        steering = theta * 10/9.0
+    else:
+        if x >= 0: x_dir = 1
+        else: x_dir = -1
+        steering = (180 - abs(theta)) * (10/9.0) * x_dir
+    '''
+    steering = x * 2.0/math.sqrt(2) * 100
+    steering = min(100,steering)
+    steering = max(-100,steering)
+    return (int(vel),int(steering))
 
 def two_joy(x,y,rt):
-	boost = 0
-	if rt <= 0:
-		boost = 50*-rt
-	if y >=0: y = (y * 50) + boost
-	else: y = (y *50) - boost
-	x *= 100
-	return (int(y),int(x))
+    max_vel = 0.3
+    forward_vel = y * max_vel
+    rotation = x * math.pi / 4
+
+    return forward_vel, rotation
 
 if __name__ == '__main__':
-	global pub
-	#global led_pub
-	rospy.init_node('joystick')
-	rospy.loginfo('joystick started')
+    global pub
+    #global led_pub
+    rospy.init_node('joystick')
+    rospy.loginfo('joystick started')
 
-	sub = rospy.Subscriber("/joy", Joy, callback)
-	pub = rospy.Publisher('joystick', Joystick, queue_size=1)
-	led_pub = rospy.Publisher('led_cmds', Int64MultiArray, queue_size=1)
+    sub = rospy.Subscriber("/joy", Joy, callback)
+    pub = rospy.Publisher('joystick', Joystick, queue_size=1)
+    led_pub = rospy.Publisher('led_cmds', Int64MultiArray, queue_size=1)
 
-	rospy.spin()
+    rospy.spin()

--- a/ROS/osr/src/joystick.py
+++ b/ROS/osr/src/joystick.py
@@ -19,9 +19,9 @@ def callback(data):
 
     led_msg = Int64MultiArray()
 
-    y =  data.axes[1]
-    x = -data.axes[0]
-    x1 =-data.axes[3]
+    y = data.axes[1]
+    x = data.axes[0]
+    x1 = data.axes[3]
     rt = data.axes[2]
 
     dpad = data.buttons[11:]
@@ -114,7 +114,7 @@ if __name__ == '__main__':
     rospy.loginfo('joystick started')
 
     sub = rospy.Subscriber("/joy", Joy, callback)
-    pub = rospy.Publisher('joystick', Joystick, queue_size=1)
+    pub = rospy.Publisher('/cmd_vel', Twist, queue_size=1)
     led_pub = rospy.Publisher('led_cmds', Int64MultiArray, queue_size=1)
 
     rospy.spin()

--- a/ROS/osr/src/joystick.py
+++ b/ROS/osr/src/joystick.py
@@ -102,7 +102,7 @@ def cartesian2polar_45(x,y):
 
 def two_joy(x,y,rt):
     max_vel = 0.3
-    forward_vel = y * max_vel
+    forward_vel = y**3 * max_vel
     rotation = x * math.pi / 4
 
     return forward_vel, rotation

--- a/ROS/osr_bringup/launch/osr.launch
+++ b/ROS/osr_bringup/launch/osr.launch
@@ -17,7 +17,15 @@
 	<node name="roboclaw_wrapper" pkg="osr" type="roboclaw_wrapper.py" output="screen">
 		<rosparam command="load" file="$(find osr_bringup)/config/roboclaw_params.yaml"/>
 	</node>
-	<node name="joystick" pkg="osr" type="joystick.py" output="screen"/>
+        <node name="joy2twist" pkg="teleop_twist_joy" type="teleop_node">
+            <param name="enable_button" value="4"/>  <!-- which button to press to enable movement-->
+            <param name="enable_turbo_button" value="5"/>  <!-- -1: disable turbo -->
+            <param name="axis_linear" value="1"/>  <!-- which joystick axis to use for driving -->
+            <param name="axis_angular" value="3"/>  <!-- which joystick axis to use for turning -->
+            <param name="scale_linear" value="0.05"/>  <!-- scale to apply to drive speed, in m/s -->
+            <param name="scale_angular" value="0.45"/>  <!-- scale to apply to angular speed, in rad/s -->
+            <param name="scale_linear_turbo" value="0.5"/>  <!-- scale to apply to linear speed, in m/s -->
+        </node>
 	<rosparam command="load" file="$(find osr_bringup)/config/physical_properties.yaml"/>
 	<node name="rover" pkg="osr" type="rover.py" output="screen"/>
 	<node name="led_screen" pkg="led_screen" type="screen.py"/>

--- a/ROS/osr_msgs/CMakeLists.txt
+++ b/ROS/osr_msgs/CMakeLists.txt
@@ -53,7 +53,6 @@ find_package(catkin REQUIRED COMPONENTS
    FILES
    CommandDrive.msg
    CommandCorner.msg
-   Joystick.msg
    Status.msg
  )
 

--- a/ROS/osr_msgs/msg/Joystick.msg
+++ b/ROS/osr_msgs/msg/Joystick.msg
@@ -1,4 +1,0 @@
-bool connected
-int64 mode
-int64 vel
-int64 steering


### PR DESCRIPTION
## Description

Instead of write our own joy to twist node, we can just use an existing one, written in C++, tested, easily modifiable for different controller types ( close #13 ): [teleop_twist_joy](http://wiki.ros.org/teleop_twist_joy)

Folks who don't have that installed yet should run
```
rosdep install --from-paths src --ignore-src
```
in their catkin workspace after updating to this commit or to just install this package only via `sudo apt install ros-$ROSDISTRO-teleop-twist-joy`

## Dependencies

- [ ] #79 