### PR TITLE
Revert "Updated drive code to use duties rather than (psuedo) qpps"

### DIFF
--- a/ROS/osr/src/roboclaw_wrapper.py
+++ b/ROS/osr/src/roboclaw_wrapper.py
@@ -2,7 +2,7 @@
 import serial
 import math
 import rospy
-import time
+
 from roboclaw import Roboclaw
 
 from sensor_msgs.msg import JointState
@@ -63,7 +63,7 @@ class RoboclawWrapper(object):
         while not rospy.is_shutdown():
 
             while self.mutex and not rospy.is_shutdown():
-                time.sleep(0.001)
+                mutex_rate.sleep()
             self.mutex = True
 
             # read from roboclaws and publish
@@ -153,7 +153,7 @@ class RoboclawWrapper(object):
         rospy.logdebug("Corner command callback received: {}".format(cmd))
 
         while self.mutex and not rospy.is_shutdown():
-            time.sleep(0.001)
+            r.sleep()
 
         self.mutex = True
 
@@ -194,29 +194,10 @@ class RoboclawWrapper(object):
         rospy.logdebug("Drive command callback received: {}".format(cmd))
 
         while self.mutex and not rospy.is_shutdown():
-            time.sleep(0.001)
+            r.sleep()
 
         self.mutex = True
-        
-        props = self.roboclaw_mapping["drive_left_front"]
-        self.send_duty_cmd(props["address"], props["channel"], int(cmd.left_front_vel))
 
-        props = self.roboclaw_mapping["drive_left_middle"]
-        self.send_duty_cmd(props["address"], props["channel"], int(cmd.left_middle_vel))
-
-        props = self.roboclaw_mapping["drive_left_back"]
-        self.send_duty_cmd(props["address"], props["channel"], int(cmd.left_back_vel))
-
-        props = self.roboclaw_mapping["drive_right_back"]
-        self.send_duty_cmd(props["address"], props["channel"], int(cmd.right_back_vel))
-
-        props = self.roboclaw_mapping["drive_right_middle"]
-        self.send_duty_cmd(props["address"], props["channel"], int(cmd.right_middle_vel))
-
-        props = self.roboclaw_mapping["drive_right_front"]
-        self.send_duty_cmd(props["address"], props["channel"], int(cmd.right_front_vel))
-        
-        """
         props = self.roboclaw_mapping["drive_left_front"]
         vel_cmd = self.velocity2qpps(cmd.left_front_vel, props["ticks_per_rev"], props["gear_ratio"])
         self.send_velocity_cmd(props["address"], props["channel"], vel_cmd)
@@ -240,7 +221,7 @@ class RoboclawWrapper(object):
         props = self.roboclaw_mapping["drive_right_front"]
         vel_cmd = self.velocity2qpps(cmd.right_front_vel, props["ticks_per_rev"], props["gear_ratio"])
         self.send_velocity_cmd(props["address"], props["channel"], vel_cmd)
-        """
+
         self.mutex = False
 
     def send_position_cmd(self, address, channel, target_tick):
@@ -287,29 +268,6 @@ class RoboclawWrapper(object):
         assert result[0] == 1
         return (result[-2], result[-1])
 
-    def send_duty_cmd(self, address, channel, speed):
-        """
-        Wrapper to send one of the speed commands.
-        
-        :param address:
-        :param channel:
-        :param speed:
-        """
-        
-        speed = speed/100.0 # scale speed to percent
-        max_duty = self.roboclaw_overflow * 0.5 # max speed/duty is half what the roboclaws can do 
-        duty = max(-max_duty, min(max_duty, speed * self.roboclaw_overflow))
-        accel = self.accel_pos
-        
-        if speed < 0:
-            accel = self.accel_neg
-        if channel == "M1":
-            return self.rc.DutyAccelM1(address, accel, int(duty))
-        elif channel == "M2":
-            return self.rc.DutyAccelM2(address, accel, int(duty))
-        else:
-            raise AttributeError("Recieved unknown channel '{}'. Expected M1 or M2".format(channel))
-        
     def send_velocity_cmd(self, address, channel, target_qpps):
         """
         Wrapper around one of the send velocity commands

--- a/ROS/osr/src/rover.py
+++ b/ROS/osr/src/rover.py
@@ -44,8 +44,7 @@ class Rover(object):
         velocity = msg.vel * max_vel / 50
         rospy.logdebug("velocity drive cmd: {} m/s".format(velocity))
         # TODO shouldn't supply commanded steering, should supply current steering.
-        #drive_cmd_msg = self.calculate_drive_velocities(velocity, desired_turning_radius)
-        drive_cmd_msg = self.calculate_drive_ratios(msg.vel, desired_turning_radius)
+        drive_cmd_msg = self.calculate_drive_velocities(velocity, desired_turning_radius)
         rospy.logdebug("drive cmd:\n{}".format(drive_cmd_msg))
         rospy.logdebug("corner cmd:\n{}".format(corner_cmd_msg)) 
         if self.corner_cmd_threshold(corner_cmd_msg):
@@ -69,65 +68,6 @@ class Rover(object):
                 return False
         except AttributeError:  # haven't received current encoder positions yet
             return True
-
-    def calculate_drive_ratios(self, speed, current_radius):
-        """
-        Calculate target speed ratios for the drive motors based on desired speed and current turning radius.
-        
-        :param speed: Drive speed command range from -max_vel to max_vel, with max vel depending on the turning radius.
-        :param radius: Current turning radius in meters.
-        """
-        # clip the value to the maximum allowed velocity
-        
-        
-        cmd_msg = CommandDrive()
-        if speed == 0:
-            return cmd_msg
-
-        elif abs(current_radius) >= self.max_radius:  # Very large turning radius, all wheels same speed 
-            cmd_msg.left_front_vel = speed
-            cmd_msg.left_middle_vel = speed
-            cmd_msg.left_back_vel = speed
-            cmd_msg.right_back_vel = speed
-            cmd_msg.right_middle_vel = speed
-            cmd_msg.right_front_vel = speed
-
-            return cmd_msg
-
-        else:
-            # for the calculations, we assume positive radius (turn left) and adjust later
-            radius = abs(current_radius)
-            # the entire vehicle moves with the same angular velocity dictated by the desired speed,
-            # around the radius of the turn. v = r * omega
-            angular_velocity_center = float(speed) / radius
-            # calculate desired velocities of all centers of wheels. Corner wheels on the same side
-            # move with the same velocity. v = r * omega again
-            r1 = (radius - self.d4)
-            r2 = ((self.d3**2 + (radius - self.d1)**2)**0.5)
-            r3 = ((self.d3**2 + (radius + self.d1)**2)**0.5)
-            r4 = (radius + self.d4)
-            
-            vel_middle_closest =  (r1/r4) * speed
-            vel_corner_closest =  (r2/r4) * speed
-            vel_corner_farthest = (r3/r4) * speed
-            vel_middle_farthest = speed
-
-            if current_radius > 0:  # turning left
-                cmd_msg.left_front_vel = vel_corner_closest
-                cmd_msg.left_back_vel = vel_corner_closest
-                cmd_msg.left_middle_vel = vel_middle_closest
-                cmd_msg.right_back_vel = vel_corner_farthest
-                cmd_msg.right_front_vel = vel_corner_farthest
-                cmd_msg.right_middle_vel = vel_middle_farthest
-            else:  # turning right
-                cmd_msg.left_front_vel = vel_corner_farthest
-                cmd_msg.left_back_vel = vel_corner_farthest
-                cmd_msg.left_middle_vel = vel_middle_farthest
-                cmd_msg.right_back_vel = vel_corner_closest
-                cmd_msg.right_front_vel = vel_corner_closest
-                cmd_msg.right_middle_vel = vel_middle_closest
-
-            return cmd_msg
 
     def calculate_drive_velocities(self, speed, current_radius):
         """

--- a/ROS/osr_bringup/config/roboclaw_params.yaml
+++ b/ROS/osr_bringup/config/roboclaw_params.yaml
@@ -36,20 +36,20 @@ roboclaw_mapping:
   corner_left_front:
     address: 132
     channel: M2
-    ticks_per_rev: 1515
-    gear_ratio: 0.5238
+    ticks_per_rev: 2000
+    gear_ratio: 0.3333
   corner_left_back:
     address: 132
     channel: M1
-    ticks_per_rev: 1526
-    gear_ratio: 0.5238
+    ticks_per_rev: 2000
+    gear_ratio: 0.3333
   corner_right_back:
     address: 131
     channel: M2
-    ticks_per_rev: 1567
-    gear_ratio: 0.5238
+    ticks_per_rev: 2000
+    gear_ratio: 0.3333
   corner_right_front:
     address: 131
     channel: M1
-    ticks_per_rev: 1596
-    gear_ratio: 0.5238
+    ticks_per_rev: 2000
+    gear_ratio: 0.3333


### PR DESCRIPTION
This change was hastily implemented and merged without review (by me). Reverts nasa-jpl/osr-rover-code#86