### PR TITLE
Custom configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 .vscode
+ROS/osr_bringup/config/*_mod.yaml

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ catkin_make
 source devel/setup.bash
 ```
 
+The rover has some customizable settings that will overwrite the default values. Whether you have any changes compared to the defaults or not, you have to manually create these files:
+```
+cd ~/osr_ws/src/osr-rover-code/ROS/osr_bringup/config
+touch physical_properties_mod.yaml roboclaw_params_mod.yaml
+```
+To change any values from the default, modify these files instead so they don't get tracked by git. The files follow the same structure as the default.
+
 ### Arduino
 
 Please refer to the instructions in 

--- a/ROS/osr_bringup/launch/osr.launch
+++ b/ROS/osr_bringup/launch/osr.launch
@@ -16,6 +16,7 @@
 	<!-- Nodes to run the Open Source Rover -->
 	<node name="roboclaw_wrapper" pkg="osr" type="roboclaw_wrapper.py" output="screen">
 		<rosparam command="load" file="$(find osr_bringup)/config/roboclaw_params.yaml"/>
+		<rosparam command="load" file="$(find osr_bringup)/config/roboclaw_params_mod.yaml"/>
 	</node>
         <node name="joy2twist" pkg="teleop_twist_joy" type="teleop_node">
             <param name="enable_button" value="4"/>  <!-- which button to press to enable movement-->
@@ -27,6 +28,7 @@
             <param name="scale_linear_turbo" value="0.5"/>  <!-- scale to apply to linear speed, in m/s -->
         </node>
 	<rosparam command="load" file="$(find osr_bringup)/config/physical_properties.yaml"/>
+	<rosparam command="load" file="$(find osr_bringup)/config/physical_properties_mod.yaml"/>
 	<node name="rover" pkg="osr" type="rover.py" output="screen"/>
 	<node name="led_screen" pkg="led_screen" type="screen.py"/>
 	<node pkg="joy"


### PR DESCRIPTION
## Decription

Force users to at least create a custom config file so folks can easily switch between branches and check out other users code without running the wrong settings on their rover. The modified parameters simply overwrite the default settings if they exist.

### Steps

in osr_bringup/config, `touch physical_properties_mod.yaml roboclaw_params_mod.yaml` or `cp` the default yaml files. 
Add or modify the lines in the `_mod.yaml` files so that they sit in the same namespace as the default files. For example, I want to overwrite the default absolute encoder `ticks_per_rev`, then in `roboclaw_params.yaml`, I add:

```
roboclaw_mapping:
  corner_left_front:
    ticks_per_rev: 1732
  corner_left_back:
    ticks_per_rev: 1714
  corner_right_back:
    ticks_per_rev: 1750
  corner_right_front:
    ticks_per_rev: 1756
```

You can also `cp` the default files, but unless you have to modify everything, I recommend only having the lines that differ from the original.

## Dependencies

- [x] #84 edits to readme so depends on readme update