### PR TITLE
motor acceleration parameters

### DIFF
--- a/ROS/osr/src/roboclaw_wrapper.py
+++ b/ROS/osr/src/roboclaw_wrapper.py
@@ -46,7 +46,7 @@ class RoboclawWrapper(object):
         # drive motor acceleration
         accel_max = 2**15-1
         accel_rate = rospy.get_param('/drive_acceleration_factor', 0.5)
-        self.acceleration = int(accel_max * accel_rate)
+        self.drive_accel = int(accel_max * accel_rate)
         self.errorCheck()
 
         self.killMotors()
@@ -297,9 +297,9 @@ class RoboclawWrapper(object):
         # clip values
         target_qpps = max(-self.roboclaw_overflow, min(self.roboclaw_overflow, target_qpps))
         if channel == "M1":
-            return self.rc.SpeedAccelM1(address, self.acceleration, target_qpps)
+            return self.rc.SpeedAccelM1(address, self.drive_accel, target_qpps)
         elif channel == "M2":
-            return self.rc.SpeedAccelM2(address, self.acceleration, target_qpps)
+            return self.rc.SpeedAccelM2(address, self.drive_accel, target_qpps)
         else:
             raise AttributeError("Received unknown channel '{}'. Expected M1 or M2".format(channel))
 

--- a/ROS/osr/src/roboclaw_wrapper.py
+++ b/ROS/osr/src/roboclaw_wrapper.py
@@ -38,12 +38,13 @@ class RoboclawWrapper(object):
 
         self.corner_max_vel = 1000
         # corner motor acceleration
-        accel_max = 655359
-        accel_rate = rospy.get_param('/corner_acceleration_factor', 0.5)
+        # Even though the actual method takes longs (2*32-1), roboclaw blog says 2**15 is 100%
+        accel_max = 2**15-1
+        accel_rate = rospy.get_param('/corner_acceleration_factor', 0.8)
         self.corner_accel = int(accel_max * accel_rate)
         self.roboclaw_overflow = 2**15-1
         # drive motor acceleration
-        accel_max = 655359
+        accel_max = 2**15-1
         accel_rate = rospy.get_param('/drive_acceleration_factor', 0.5)
         self.acceleration = int(accel_max * accel_rate)
         self.errorCheck()

--- a/ROS/osr/src/roboclaw_wrapper.py
+++ b/ROS/osr/src/roboclaw_wrapper.py
@@ -39,10 +39,10 @@ class RoboclawWrapper(object):
         self.corner_max_vel = 1000
         self.corner_accel = 2000
         self.roboclaw_overflow = 2**15-1
+        # drive motor acceleration
         accel_max = 655359
-        accel_rate = 0.5
-        self.accel_pos = int((accel_max /2) + accel_max * accel_rate)
-        self.accel_neg = int((accel_max /2) - accel_max * accel_rate)
+        accel_rate = rospy.get_param('/acceleration_factor', 0.5)
+        self.acceleration = int(accel_max * accel_rate)
         self.errorCheck()
 
         self.killMotors()
@@ -292,11 +292,10 @@ class RoboclawWrapper(object):
         """
         # clip values
         target_qpps = max(-self.roboclaw_overflow, min(self.roboclaw_overflow, target_qpps))
-        accel = self.accel_pos
         if channel == "M1":
-            return self.rc.SpeedAccelM1(address, accel, target_qpps)
+            return self.rc.SpeedAccelM1(address, self.acceleration, target_qpps)
         elif channel == "M2":
-            return self.rc.SpeedAccelM2(address, accel, target_qpps)
+            return self.rc.SpeedAccelM2(address, self.acceleration, target_qpps)
         else:
             raise AttributeError("Received unknown channel '{}'. Expected M1 or M2".format(channel))
 

--- a/ROS/osr/src/roboclaw_wrapper.py
+++ b/ROS/osr/src/roboclaw_wrapper.py
@@ -37,11 +37,14 @@ class RoboclawWrapper(object):
             self.rc.ReadNVM(address)
 
         self.corner_max_vel = 1000
-        self.corner_accel = 2000
+        # corner motor acceleration
+        accel_max = 655359
+        accel_rate = rospy.get_param('/corner_acceleration_factor', 0.5)
+        self.corner_accel = int(accel_max * accel_rate)
         self.roboclaw_overflow = 2**15-1
         # drive motor acceleration
         accel_max = 655359
-        accel_rate = rospy.get_param('/acceleration_factor', 0.5)
+        accel_rate = rospy.get_param('/drive_acceleration_factor', 0.5)
         self.acceleration = int(accel_max * accel_rate)
         self.errorCheck()
 

--- a/ROS/osr_bringup/config/physical_properties.yaml
+++ b/ROS/osr_bringup/config/physical_properties.yaml
@@ -7,4 +7,4 @@ rover_dimensions:
 drive_no_load_rpm: 130  # no load speed for the drive motors
 speed_adjustment_factor: 0.1  # scale down velocity from no load rpm due to weight of rover
 drive_acceleration_factor: 0.5  # fraction used to scale the drive motor acceleration (0, 1]
-corner_acceleration_factor: 0.5  # fraction used to scale the corner motor acceleration (0, 1])
+corner_acceleration_factor: 0.8  # fraction used to scale the corner motor acceleration (0, 1])

--- a/ROS/osr_bringup/config/physical_properties.yaml
+++ b/ROS/osr_bringup/config/physical_properties.yaml
@@ -6,3 +6,4 @@ rover_dimensions:
   wheel_radius: 0.075  # [m]
 drive_no_load_rpm: 130  # no load speed for the drive motors
 speed_adjustment_factor: 0.1  # scale down velocity from no load rpm due to weight of rover
+acceleration_factor: 0.5  # fraction used to scale the drive motor acceleration (0, 1]

--- a/ROS/osr_bringup/config/physical_properties.yaml
+++ b/ROS/osr_bringup/config/physical_properties.yaml
@@ -6,4 +6,5 @@ rover_dimensions:
   wheel_radius: 0.075  # [m]
 drive_no_load_rpm: 130  # no load speed for the drive motors
 speed_adjustment_factor: 0.1  # scale down velocity from no load rpm due to weight of rover
-acceleration_factor: 0.5  # fraction used to scale the drive motor acceleration (0, 1]
+drive_acceleration_factor: 0.5  # fraction used to scale the drive motor acceleration (0, 1]
+corner_acceleration_factor: 0.5  # fraction used to scale the corner motor acceleration (0, 1])


### PR DESCRIPTION
## Description

* set the drive and corner motor acceleration using a ROS param, in `physical_properties_mod.yaml`
* change the default from max to half the max acceleration. That will let the rover slow down and speed up slower, increasing gearbox lifetime. Also fix the max to be 2**15-1 iso `655359`. See [roboclaw blog](https://resources.basicmicro.com/understanding-acceleration-and-deceleration-values/) for details.

## Dependencies

None