### PR TITLE
divide status values by 10, change message definitions

### DIFF
--- a/ROS/osr/src/roboclaw_wrapper.py
+++ b/ROS/osr/src/roboclaw_wrapper.py
@@ -403,8 +403,8 @@ class RoboclawWrapper(object):
         for i in range(5):
             currs = self.rc.ReadCurrents(self.address[i])
             # reported by roboclaw in 10ths of an Ampere
-            currents[2*i] = currs[1] / 10.0
-            currents[(2*i) + 1] = currs[2] / 10.0
+            currents[2*i] = currs[1] / 100.0
+            currents[(2*i) + 1] = currs[2] / 100.0
         
         return currents
 

--- a/ROS/osr/src/roboclaw_wrapper.py
+++ b/ROS/osr/src/roboclaw_wrapper.py
@@ -26,7 +26,7 @@ class RoboclawWrapper(object):
         self.roboclaw_mapping = rospy.get_param('~roboclaw_mapping')
         self.encoder_limits = {}
         self.establish_roboclaw_connections()
-        self.killMotors()  # don't move at start
+        self.stop_motors()  # don't move at start
         self.setup_encoders()
 
         # save settings to non-volatile (permanent) memory
@@ -47,9 +47,8 @@ class RoboclawWrapper(object):
         accel_max = 2**15-1
         accel_rate = rospy.get_param('/drive_acceleration_factor', 0.5)
         self.drive_accel = int(accel_max * accel_rate)
-        self.errorCheck()
 
-        self.killMotors()
+        self.stop_motors()
 
         # set up publishers and subscribers
         self.corner_cmd_sub = rospy.Subscriber("/cmd_corner", CommandCorner, self.corner_cmd_cb, queue_size=1)
@@ -86,10 +85,10 @@ class RoboclawWrapper(object):
 
             # Downsample the rate of less important data
             if (counter >= 5):
-                status.battery = self.getBattery()
-                status.temp = self.getTemp()
-                status.current = self.getCurrents()
-                status.error_status = self.getErrors()
+                status.battery = self.read_battery()
+                status.temp = self.read_temperatures()
+                status.current = self.read_currents()
+                status.error_status = self.read_errors()
                 counter = 0
 
             self.status_pub.publish(status)
@@ -386,40 +385,44 @@ class RoboclawWrapper(object):
         """
         return int(velocity * gear_ratio * ticks_per_rev / (2 * math.pi))
 
-    def getBattery(self):
-        return self.rc.ReadMainBatteryVoltage(self.address[0])[1]
+    def read_battery(self):
+        """Read battery voltage from one of the roboclaws as a proxy for all roboclaws"""
+        # roboclaw reports value in 10ths of a Volt
+        return self.rc.ReadMainBatteryVoltage(self.address[0])[1] / 10.0
 
-    def getTemp(self):
+    def read_temperatures(self):
         temp = [None] * 5
         for i in range(5):
-            temp[i] = self.rc.ReadTemp(self.address[i])[1]
+            # reported by roboclaw in 10ths of a Celsius
+            temp[i] = self.rc.ReadTemp(self.address[i])[1] / 10.0
+        
         return temp
 
-    def getCurrents(self):
+    def read_currents(self):
         currents = [None] * 10
         for i in range(5):
             currs = self.rc.ReadCurrents(self.address[i])
-            currents[2*i] = currs[1]
-            currents[(2*i) + 1] = currs[2]
+            # reported by roboclaw in 10ths of an Ampere
+            currents[2*i] = currs[1] / 10.0
+            currents[(2*i) + 1] = currs[2] / 10.0
+        
         return currents
 
-    def getErrors(self):
-        return self.err
-
-    def killMotors(self):
+    def stop_motors(self):
         """Stops all motors on Rover"""
         for i in range(5):
             self.rc.ForwardM1(self.address[i], 0)
             self.rc.ForwardM2(self.address[i], 0)
 
-    def errorCheck(self):
-        """Checks error status of each motor controller, returns 0 if any errors occur"""
+    def read_errors(self):
+        """Checks error status of each motor controller, returns 0 if no errors reported"""
+        err = [0] * 5
         for i in range(len(self.address)):
-            self.err[i] = self.rc.ReadError(self.address[i])[1]
-        for error in self.err:
-            if error:
-                self.killMotors()
-                rospy.logerr("Motor controller Error: \n'{}'".format(error))
+            err[i] = self.rc.ReadError(self.address[i])[1]
+            if err[i] != 0:
+                rospy.logerr("Motor controller '{}' reported error code {}".format(self.address[i], err[i]))
+        
+        return err
 
 
 if __name__ == "__main__":
@@ -427,5 +430,5 @@ if __name__ == "__main__":
     rospy.loginfo("Starting the roboclaw wrapper node")
 
     wrapper = RoboclawWrapper()
-    rospy.on_shutdown(wrapper.killMotors)
+    rospy.on_shutdown(wrapper.stop_motors)
     wrapper.run()

--- a/ROS/osr_msgs/msg/Status.msg
+++ b/ROS/osr_msgs/msg/Status.msg
@@ -1,7 +1,7 @@
 # voltage level being read into the RoboClaws, in Volts
 float32 battery
 # status of an error being present on each RoboClaw. 1 if Error, 0 otherwise
-int16[5] error_status
+int32[5] error_status
 # Temperature of the motor controllers expressed in Celsius
 float32[5] temp
 # Sensed current from the motor controllers in Ampere

--- a/ROS/osr_msgs/msg/Status.msg
+++ b/ROS/osr_msgs/msg/Status.msg
@@ -1,8 +1,8 @@
-# voltage level being read into the RoboClaws. The value is 10 x [Battery Voltage(V)]
-int64     battery
+# voltage level being read into the RoboClaws, in Volts
+float32 battery
 # status of an error being present on each RoboClaw. 1 if Error, 0 otherwise
-int64[5]  error_status
-# Temperature of the motor controllers. The value is 10 x (Temperature[C])
-int64[5]  temp
-# Sensed current from the motor controllers. current drawn on each motor. The value is 10 x (Current(A)
-int64[10] current
+int16[5] error_status
+# Temperature of the motor controllers expressed in Celsius
+float32[5] temp
+# Sensed current from the motor controllers in Ampere
+float32[10] current


### PR DESCRIPTION
See #97 and #58 

also closes #102 

This also checks for errors more continuously (this previously only happened on startup) and logs them to console in addition to adding them to the message.