### PR TITLE
Clarify instructions in README + update default gamepad velocity values

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,33 @@ catkin_make
 source devel/setup.bash
 ```
 
-The rover has some customizable settings that will overwrite the default values. Whether you have any changes compared to the defaults or not, you have to manually create these files:
+The rover has some customizable settings that will overwrite the default values. 
+Whether you have any changes compared to the defaults or not, you have to manually create these files:
 ```
 cd ~/osr_ws/src/osr-rover-code/ROS/osr_bringup/config
 touch physical_properties_mod.yaml roboclaw_params_mod.yaml
 ```
-To change any values from the default, modify these files instead so they don't get tracked by git. The files follow the same structure as the default.
+If your rover doesn't have any modifications to it that would affect any of the paremeters in `physical_properties.yaml`
+or in `roboclaw_params.yaml`, you do not have to do anything.
+To change any values from the default, modify these files instead so they don't get tracked by git. 
+The files follow the same structure as the default. Just include the values that you need to change as the default
+values for other parameters may change over time.
+
+You might also want to modify the file `ROS/osr_bringup/osr.launch` to change the velocities the gamepad controller will
+send to the rover. These values in the node joy2twist are of interest:
+```
+<param name="scale_linear" value="0.18"/>
+<param name="scale_angular" value="0.4"/>
+<param name="scale_linear_turbo" value="0.24"/>
+```
+The maximum speed your rover can go is determined by the no-load speed of your drive motors. The default value is located
+in the file [physical_properties.yaml](ROS/osr_bringupconfig/physical_properties.yaml) as `drive_no_load_rpm`. 
+Then the value of `scale_linear_turbo` can be calculated as `drive_no_load_rpm * 2pi / 60 * wheel radius (=0.075m)`.
+Based on this max value, let's set our regular moving speed to a fraction of that which you can configure to your liking.
+Start with e.g. 0.75 * scale_linear_turbo.
+
+The turning speed of the rover, just like a regular car, depends on how fast it's going. As a result, `scale_angular`
+should be set to `scale_linear / min_radius`. For the default configuration, the `min_radius` equals `0.45m`.
 
 ### Arduino
 
@@ -46,7 +67,10 @@ roslaunch osr_bringup osr.launch
 ```
 to run the rover.
 Any errors or warnings will be displayed there in case something went wrong. If you're using the Xbox wireless controller,
-command the rover by holding the left back button (LB) down and moving the joysticks.
+command the rover by holding the left back button (LB) down and moving the joysticks. You can boost as described above
+by holding down the right back button (RB) instead. If this isn't working for you, `rostopic echo /joy`, press buttons,
+and adjust `bringup.launch` to point to the corresponding buttons and axes. If you have questions, please ask on the 
+Tapatalk forum.
 
 ## Internals & Structure
 

--- a/ROS/osr_bringup/launch/osr.launch
+++ b/ROS/osr_bringup/launch/osr.launch
@@ -11,9 +11,9 @@
             <param name="enable_turbo_button" value="5"/>  <!-- -1: disable turbo -->
             <param name="axis_linear" value="1"/>  <!-- which joystick axis to use for driving -->
             <param name="axis_angular" value="3"/>  <!-- which joystick axis to use for turning -->
-            <param name="scale_linear" value="0.24"/>  <!-- scale to apply to drive speed, in m/s: drive_motor_rpm * 2pi / 60 * wheel radius -->
-            <param name="scale_angular" value="0.53"/>  <!-- scale to apply to angular speed, in rad/s: scale_linear / min_radius -->
-            <param name="scale_linear_turbo" value="0.5"/>  <!-- scale to apply to linear speed, in m/s -->
+            <param name="scale_linear" value="0.18"/>  <!-- scale to apply to drive speed, in m/s: drive_motor_rpm * 2pi / 60 * wheel radius -->
+            <param name="scale_angular" value="0.4"/>  <!-- scale to apply to angular speed, in rad/s: scale_linear / min_radius -->
+            <param name="scale_linear_turbo" value="0.24"/>  <!-- scale to apply to linear speed, in m/s -->
         </node>
 	<rosparam command="load" file="$(find osr_bringup)/config/physical_properties.yaml"/>
 	<rosparam command="load" file="$(find osr_bringup)/config/physical_properties_mod.yaml"/>


### PR DESCRIPTION
Added some extra clarifications + verbosity to the main README
The default velocities for the default drive motor configuration (31rpm) was also incorrect with the velocities for turbo being way too high.