### PR TITLE
Update defaults to GoBilda motors

### DIFF
--- a/ROS/osr_bringup/config/physical_properties.yaml
+++ b/ROS/osr_bringup/config/physical_properties.yaml
@@ -4,7 +4,7 @@ rover_dimensions:
   d3: 0.267  # [m, ~10.5in]
   d4: 0.2556  # [m, ~10.073in]
   wheel_radius: 0.075  # [m]
-drive_no_load_rpm: 31  # no load speed for the drive motors
+drive_no_load_rpm: 223  # no load speed for the drive motors
 drive_acceleration_factor: 0.5  # fraction used to scale the drive motor acceleration (0, 1]
 corner_acceleration_factor: 0.8  # fraction used to scale the corner motor acceleration (0, 1])
 velocity_timeout: 2.0  # maximum time [s] a particular velocity command will stay active without a new command before stopping

--- a/ROS/osr_bringup/config/roboclaw_params.yaml
+++ b/ROS/osr_bringup/config/roboclaw_params.yaml
@@ -1,36 +1,36 @@
 roboclaw_mapping:
-  # gear ratio is approx 172, exact value is 171.79 though
+  # gear ratio is approx 172, exact value is 26.9 though
   drive_left_front:
     address: 130
     channel: M2
-    ticks_per_rev: 48
-    gear_ratio: 171.79
+    ticks_per_rev: 28
+    gear_ratio: 26.9
   drive_left_middle:
     address: 130
     channel: M1
-    ticks_per_rev: 48
-    gear_ratio: 171.79
+    ticks_per_rev: 28
+    gear_ratio: 26.9
   drive_left_back:
     address: 129
     channel: M2
-    ticks_per_rev: 48
-    gear_ratio: 171.79
+    ticks_per_rev: 28
+    gear_ratio: 26.9
   drive_right_back:
     address: 129
     channel: M1
-    ticks_per_rev: 48
-    gear_ratio: 171.79
+    ticks_per_rev: 28
+    gear_ratio: 26.9
   drive_right_middle:
     address: 128
     channel: M2
-    ticks_per_rev: 48
-    gear_ratio: 171.79
+    ticks_per_rev: 28
+    gear_ratio: 26.9
   drive_right_front:
     address: 128
     channel: M1
-    ticks_per_rev: 48
-    gear_ratio: 171.79
-  # gear ratio for the corner motors is 16/48 as the CPR is measured after the gearbox, but
+    ticks_per_rev: 28
+    gear_ratio: 26.9
+  # gear ratio for the corner motors is 16/28 as the CPR is measured after the gearbox, but
   # to the output shaft through the gears connecting the absolute encoder
   # ticks per revolution for the absolute analog encoders: 0-2V with 1mV steps --> 2000
   corner_left_front:

--- a/ROS/osr_bringup/config/roboclaw_params.yaml
+++ b/ROS/osr_bringup/config/roboclaw_params.yaml
@@ -30,7 +30,7 @@ roboclaw_mapping:
     channel: M1
     ticks_per_rev: 28
     gear_ratio: 26.9
-  # gear ratio for the corner motors is 16/28 as the CPR is measured after the gearbox, but
+  # gear ratio for the corner motors is 16/48 as the CPR is measured after the gearbox, but
   # to the output shaft through the gears connecting the absolute encoder
   # ticks per revolution for the absolute analog encoders: 0-2V with 1mV steps --> 2000
   corner_left_front:

--- a/ROS/osr_bringup/launch/osr.launch
+++ b/ROS/osr_bringup/launch/osr.launch
@@ -11,9 +11,9 @@
             <param name="enable_turbo_button" value="5"/>  <!-- -1: disable turbo -->
             <param name="axis_linear" value="1"/>  <!-- which joystick axis to use for driving -->
             <param name="axis_angular" value="3"/>  <!-- which joystick axis to use for turning -->
-            <param name="scale_linear" value="0.24"/>  <!-- scale to apply to drive speed, in m/s: drive_motor_rpm * 2pi / 60 * wheel radius -->
-            <param name="scale_angular" value="0.53"/>  <!-- scale to apply to angular speed, in rad/s: scale_linear / min_radius -->
-            <param name="scale_linear_turbo" value="0.5"/>  <!-- scale to apply to linear speed, in m/s -->
+            <param name="scale_linear" value="0.8"/>  <!-- scale to apply to drive speed, in m/s: drive_motor_rpm * 2pi / 60 * wheel radius -->
+            <param name="scale_angular" value="1.75"/>  <!-- scale to apply to angular speed, in rad/s: scale_linear / min_radius -->
+            <param name="scale_linear_turbo" value="1.78"/>  <!-- scale to apply to linear speed, in m/s -->
 			<remap from="/cmd_vel" to="/cmd_vel_intuitive"/>
         </node>
 	<rosparam command="load" file="$(find osr_bringup)/config/physical_properties.yaml"/>


### PR DESCRIPTION
Now that the open-source-rover repo has GoBilda as the default drive motors, the code must follow too to. For those with different motors, make use of the `_mod.yaml` files as described in the README to update the file to reflect your motors if they corresponded to the defaults.