### PR TITLE
Robustify launch script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 .vscode
 ROS/osr_bringup/config/*_mod.yaml
+*.sublime-project
+*.sublime-workspace

--- a/ROS/osr_bringup/launch/.gitignore
+++ b/ROS/osr_bringup/launch/.gitignore
@@ -1,0 +1,1 @@
+osr_mod.launch

--- a/init_scripts/LaunchOSR.sh
+++ b/init_scripts/LaunchOSR.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
+
+source osr_paths.sh
+launch_dir=$OSR_CODE_DIR/ROS/osr_bringup/launch
+
 bash -c ". /home/$USER/osr_ws/devel/setup.sh"
 bash -c ". /home/$USER/osr_ws/devel/setup.bash"
 bash -c ". /opt/ros/kinetic/setup.sh"
 bash -c ". /opt/ros/kinetic/setup.bash"
-bash -i -c "roslaunch osr_bringup osr.launch"
+
+# execute the custom mod launch file if it's available
+if [ -e "$launch_dir/osr_mod.launch" ]; then
+    bash -i -c "roslaunch osr_bringup osr_mod.launch"
+# otherwise go with the default
+else
+    bash -i -c "roslaunch osr_bringup osr.launch"
+fi

--- a/init_scripts/launch_osr.sh
+++ b/init_scripts/launch_osr.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
+# exit on error, and output executed commands to stdout
+set -ex
 
 source osr_paths.sh
 launch_dir=$OSR_CODE_DIR/ROS/osr_bringup/launch
 
 bash -c ". /home/$USER/osr_ws/devel/setup.sh"
 bash -c ". /home/$USER/osr_ws/devel/setup.bash"
-bash -c ". /opt/ros/kinetic/setup.sh"
-bash -c ". /opt/ros/kinetic/setup.bash"
+bash -c ". /opt/ros/melodic/setup.sh"
+bash -c ". /opt/ros/melodic/setup.bash"
 
 # execute the custom mod launch file if it's available
 if [ -e "$launch_dir/osr_mod.launch" ]; then
+    echo "Launching osr_mod.launch"
     bash -i -c "roslaunch osr_bringup osr_mod.launch"
 # otherwise go with the default
 else
+    echo "Launching osr.launch"
     bash -i -c "roslaunch osr_bringup osr.launch"
 fi

--- a/init_scripts/osr_paths.sh
+++ b/init_scripts/osr_paths.sh
@@ -1,0 +1,3 @@
+## Paths used for OSR code
+# make sure to source (`$ source osr_paths.sh`) this script!
+export OSR_CODE_DIR=$HOME/osr_ws/src/osr-rover-code

--- a/init_scripts/osr_startup.service
+++ b/init_scripts/osr_startup.service
@@ -6,7 +6,7 @@ After=network.target
 User=ubuntu
 Group=ubuntu
 WorkingDirectory=/home/ubuntu/
-ExecStart=/home/ubuntu/LaunchOSR.sh
+ExecStart=/home/ubuntu/launch_osr.sh
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 

--- a/setup/rover_bringup.md
+++ b/setup/rover_bringup.md
@@ -16,7 +16,13 @@ command the rover by holding the left back button (LB) down and moving the joyst
 the [RPi setup](rpi.md) by holding down the right back button (RB) instead. If this isn't working for you, 
 `rostopic echo /joy`, press buttons, and adjust `bringup.launch` to point to the corresponding buttons and axes. If you have questions, please ask on the Tapatalk forum.
 
-## 2 Automatic bringup with init script
+## 2 Custom osr_mod.launch file
+
+If you want to customize your `osr.launch` file, make a copy of it in the same directory (`osr-rover-code/ROS/osr_bringup/launch/`) and name it osr_mod.launch. The OSR launch script will automatically find it.
+
+This is useful, for example, when you don't have the LED screen. Just remove the `<node name="led_screen" pkg="led_screen" type="arduino_comm.py"/>` line in osr_mod.launch.
+
+## 3 Automatic bringup with launch script
 
 Starting scripts on boot using ROS can be a little more difficult than starting scripts on boot normally from
 the Raspberry Pi because of the default permission settings on the RPi and the fact that that ROS cannot
@@ -29,8 +35,9 @@ roslaunch file, and the other creates a system service to start that bash script
 raspberry Pi and execute the following commands.
 ```
 cd ~/osr_ws/src/osr-rover-code/init_scripts
-sudo cp LaunchOSR.sh ~/LaunchOSR.sh
-sudo chmod +x ~/LaunchOSR.sh
+# use symbolic links so we capture updates to these files in the service
+ln -s $(pwd)/launch_osr.sh ~/launch_osr.sh
+ln -s $(pwd)/osr_paths.sh ~/osr_paths.sh
 sudo cp osr_startup.service /etc/systemd/system/osr_startup.service
 sudo chmod 644 /etc/systemd/system/osr_startup.service
 ```

--- a/setup/rover_bringup.md
+++ b/setup/rover_bringup.md
@@ -20,7 +20,7 @@ the [RPi setup](rpi.md) by holding down the right back button (RB) instead. If t
 
 If you want to customize your `osr.launch` file, make a copy of it in the same directory (`osr-rover-code/ROS/osr_bringup/launch/`) and name it `osr_mod.launch`. The OSR launch script will automatically find it.
 
-This is useful, for example, when you don't have the LED screen. Just remove the `<node name="led_screen" pkg="led_screen" type="arduino_comm.py"/>` line in osr_mod.launch.
+This is useful, for example, when you don't have the LED screen. In that case you would just remove the `<node name="led_screen" pkg="led_screen" type="arduino_comm.py"/>` line in `osr_mod.launch`.
 
 ## 3 Automatic bringup with launch script
 

--- a/setup/rover_bringup.md
+++ b/setup/rover_bringup.md
@@ -18,7 +18,7 @@ the [RPi setup](rpi.md) by holding down the right back button (RB) instead. If t
 
 ## 2 Custom osr_mod.launch file
 
-If you want to customize your `osr.launch` file, make a copy of it in the same directory (`osr-rover-code/ROS/osr_bringup/launch/`) and name it osr_mod.launch. The OSR launch script will automatically find it.
+If you want to customize your `osr.launch` file, make a copy of it in the same directory (`osr-rover-code/ROS/osr_bringup/launch/`) and name it `osr_mod.launch`. The OSR launch script will automatically find it.
 
 This is useful, for example, when you don't have the LED screen. Just remove the `<node name="led_screen" pkg="led_screen" type="arduino_comm.py"/>` line in osr_mod.launch.
 


### PR DESCRIPTION
Made the launch script more robust
- using symbolic links now so that updates get captured in the systemd service
- allow usage of custom osr_mod.launch file if you want to disclude e.g. the led screen node
