### PR TITLE
Changed pose covariance to twist

### DIFF
--- a/ROS/osr/src/rover.py
+++ b/ROS/osr/src/rover.py
@@ -107,10 +107,10 @@ class Rover(object):
             self.odometry.pose.pose.position.y += math.sin(new_angle) * dx
             self.odometry.pose.covariance = 36 * [0.0,]
             # explanation for values at https://www.freedomrobotics.ai/blog/tuning-odometry-for-wheeled-robots
-            self.odometry.pose.covariance[0] = 0.0225
-            self.odometry.pose.covariance[5] = 0.01
-            self.odometry.pose.covariance[-5] = 0.0225
-            self.odometry.pose.covariance[-1] = 0.04
+            self.odometry.twist.covariance[0] = 0.0225
+            self.odometry.twist.covariance[5] = 0.01
+            self.odometry.twist.covariance[-5] = 0.0225
+            self.odometry.twist.covariance[-1] = 0.04
             self.odometry.twist = self.curr_twist
             self.odometry.header.stamp = now
             self.odometry_pub.publish(self.odometry)


### PR DESCRIPTION
The covariance values describe the linear and angular velocity covariances, but they are placed in the pose covariance matrix.