### PR TITLE
INA260 support

### DIFF
--- a/scripts/ina260/test_ina260.py
+++ b/scripts/ina260/test_ina260.py
@@ -1,0 +1,21 @@
+import argparse
+from ina260.controller import Controller
+
+parser = argparse.ArgumentParser()
+addr_help = \
+"""
+i2c address of your ina260 in hexadecimal. Default 0x40. You can verify that it is detected using 'sudo i2cdetect 1'.
+You should see one entry that's not empty in the table. Specify that number as the argument to this script, e.g. 0x41.
+"""
+parser.add_argument("address", help=addr_help, type=lambda x: int(x, 16), nargs='?', default='0x40')
+args = parser.parse_args()
+
+print(f"Attempting to connect INA260 at address {hex(args.address)}...\n")
+
+c = Controller(args.address)
+try:
+    print("Successfully read values. They should be nonzero:\n"
+          f"Current: {round(c.current(), 3)} A\nVoltage: {round(c.voltage(), 3)} V\nPower: {round(c.power(), 2)} W")
+except OSError as e:
+    print("Unable to connect to your INA260.")
+    parser.print_help()


### PR DESCRIPTION
Uses the ina260 library (`pip3 install ina260`) to get current, voltage, power readouts. Add to default launch.

- [ ] remove existing ina260 code
- [ ] add dependency on ina260 (doesn't seem to be on rosdistro...)
- [ ] write ros 2 node that converts readouts to message and publishes

Future work could include integrating low battery capacity readouts into some warning system.