### PR TITLE
Replace None's with parameter types

### DIFF
--- a/ROS/osr_control/osr_control/roboclaw_wrapper.py
+++ b/ROS/osr_control/osr_control/roboclaw_wrapper.py
@@ -2,6 +2,7 @@ import math
 from collections import defaultdict
 
 import rclpy
+from rclpy.parameter import Parameter
 from rclpy.node import Node
 
 from osr_control.roboclaw import Roboclaw
@@ -28,37 +29,37 @@ class RoboclawWrapper(Node):
         self.declare_parameters(
             namespace='',
             parameters=[
-                ('baud_rate', None),
-                ('device', None),
-                ('addresses', None),
-                ('roboclaw_mapping', None),
-                ('drive_acceleration_factor', None),
-                ('corner_acceleration_factor', None),
-                ('velocity_timeout', None),
-                ('roboclaw_mapping.drive_left_front.address', None),
-                ('roboclaw_mapping.drive_left_front.channel', None),
-                ('roboclaw_mapping.drive_left_front.ticks_per_rev', None),
-                ('roboclaw_mapping.drive_left_front.gear_ratio', None),
-                ('roboclaw_mapping.drive_left_middle.address', None),
-                ('roboclaw_mapping.drive_left_middle.channel', None),
-                ('roboclaw_mapping.drive_left_middle.ticks_per_rev', None),
-                ('roboclaw_mapping.drive_left_middle.gear_ratio', None),
-                ('roboclaw_mapping.drive_left_back.address', None),
-                ('roboclaw_mapping.drive_left_back.channel', None),
-                ('roboclaw_mapping.drive_left_back.ticks_per_rev', None),
-                ('roboclaw_mapping.drive_left_back.gear_ratio', None),
-                ('roboclaw_mapping.drive_right_front.address', None),
-                ('roboclaw_mapping.drive_right_front.channel', None),
-                ('roboclaw_mapping.drive_right_front.ticks_per_rev', None),
-                ('roboclaw_mapping.drive_right_front.gear_ratio', None),
-                ('roboclaw_mapping.drive_right_middle.address', None),
-                ('roboclaw_mapping.drive_right_middle.channel', None),
-                ('roboclaw_mapping.drive_right_middle.ticks_per_rev', None),
-                ('roboclaw_mapping.drive_right_middle.gear_ratio', None),
-                ('roboclaw_mapping.drive_right_back.address', None),
-                ('roboclaw_mapping.drive_right_back.channel', None),
-                ('roboclaw_mapping.drive_right_back.ticks_per_rev', None),
-                ('roboclaw_mapping.drive_right_back.gear_ratio', None)
+                ('baud_rate', Parameter.Type.INTEGER),
+                ('device', Parameter.Type.STRING),
+                ('addresses', Parameter.Type.INTEGER_ARRAY),
+                # ('roboclaw_mapping', Parameter.Type.INTEGER_ARRAY),
+                ('drive_acceleration_factor', Parameter.Type.DOUBLE),
+                ('corner_acceleration_factor', Parameter.Type.DOUBLE),
+                ('velocity_timeout', Parameter.Type.DOUBLE),
+                ('roboclaw_mapping.drive_left_front.address', Parameter.Type.INTEGER),
+                ('roboclaw_mapping.drive_left_front.channel', Parameter.Type.STRING),
+                ('roboclaw_mapping.drive_left_front.ticks_per_rev', Parameter.Type.INTEGER),
+                ('roboclaw_mapping.drive_left_front.gear_ratio', Parameter.Type.DOUBLE),
+                ('roboclaw_mapping.drive_left_middle.address', Parameter.Type.INTEGER),
+                ('roboclaw_mapping.drive_left_middle.channel', Parameter.Type.STRING),
+                ('roboclaw_mapping.drive_left_middle.ticks_per_rev', Parameter.Type.INTEGER),
+                ('roboclaw_mapping.drive_left_middle.gear_ratio', Parameter.Type.DOUBLE),
+                ('roboclaw_mapping.drive_left_back.address', Parameter.Type.INTEGER),
+                ('roboclaw_mapping.drive_left_back.channel', Parameter.Type.STRING),
+                ('roboclaw_mapping.drive_left_back.ticks_per_rev', Parameter.Type.INTEGER),
+                ('roboclaw_mapping.drive_left_back.gear_ratio', Parameter.Type.DOUBLE),
+                ('roboclaw_mapping.drive_right_front.address', Parameter.Type.INTEGER),
+                ('roboclaw_mapping.drive_right_front.channel', Parameter.Type.STRING),
+                ('roboclaw_mapping.drive_right_front.ticks_per_rev', Parameter.Type.INTEGER),
+                ('roboclaw_mapping.drive_right_front.gear_ratio', Parameter.Type.DOUBLE),
+                ('roboclaw_mapping.drive_right_middle.address', Parameter.Type.INTEGER),
+                ('roboclaw_mapping.drive_right_middle.channel', Parameter.Type.STRING),
+                ('roboclaw_mapping.drive_right_middle.ticks_per_rev', Parameter.Type.INTEGER),
+                ('roboclaw_mapping.drive_right_middle.gear_ratio', Parameter.Type.DOUBLE),
+                ('roboclaw_mapping.drive_right_back.address', Parameter.Type.INTEGER),
+                ('roboclaw_mapping.drive_right_back.channel', Parameter.Type.STRING),
+                ('roboclaw_mapping.drive_right_back.ticks_per_rev', Parameter.Type.INTEGER),
+                ('roboclaw_mapping.drive_right_back.gear_ratio', Parameter.Type.DOUBLE)
             ]
         )
 

--- a/ROS/osr_control/osr_control/rover.py
+++ b/ROS/osr_control/osr_control/rover.py
@@ -2,6 +2,7 @@ import math
 from functools import partial
 
 import rclpy
+from rclpy.parameter import Parameter
 from rclpy.node import Node
 import tf2_ros
 
@@ -24,13 +25,13 @@ class Rover(Node):
         self.declare_parameters(
             namespace='',
             parameters=[
-                ('rover_dimensions.d1', None),
-                ('rover_dimensions.d2', None),
-                ('rover_dimensions.d3', None),
-                ('rover_dimensions.d4', None),
-                ('rover_dimensions.wheel_radius', None),
-                ('drive_no_load_rpm', None),
-                ('enable_odometry', None)
+                ('rover_dimensions.d1', Parameter.Type.DOUBLE),
+                ('rover_dimensions.d2', Parameter.Type.DOUBLE),
+                ('rover_dimensions.d3', Parameter.Type.DOUBLE),
+                ('rover_dimensions.d4', Parameter.Type.DOUBLE),
+                ('rover_dimensions.wheel_radius', Parameter.Type.DOUBLE),
+                ('drive_no_load_rpm', Parameter.Type.DOUBLE),
+                ('enable_odometry', Parameter.Type.BOOL)
             ]
         )
         self.d1 = self.get_parameter('rover_dimensions.d1').get_parameter_value().double_value


### PR DESCRIPTION
This fixes the error 

```
clpy.exceptions.InvalidParameterTypeException: Trying to set parameter 'rover_dimensions.d1' to '0.177' of type 'DOUBLE', expecting type 'NOT_SET'
```

which is a phenomenon that occurs on newer versions of ROS 2 (not on foxy/galactic).

@abust005 