### PR TITLE
roboclawtest.py serial connections are not no longer mutually exclusive 

### DIFF
--- a/scripts/roboclawtest.py
+++ b/scripts/roboclawtest.py
@@ -19,13 +19,22 @@ if __name__ == "__main__":
     roboclaw1 = Roboclaw("/dev/serial1", 115200)
     connected0 = roboclaw0.Open() == 1
     connected1 = roboclaw1.Open() == 1
+    one_connected = False
     if connected0:
         print("Connected to /dev/serial0.")
-        print(roboclaw0.ReadVersion(address))
-        print(roboclaw0.ReadEncM1(address))
-    elif connected1:
+        print(f"Address: {address}")
+        print("ReadVersion:", roboclaw0.ReadVersion(address))
+        print("ReadEncM1:", roboclaw0.ReadEncM1(address))
+        battery = roboclaw0.ReadMainBatteryVoltage(address)
+        print(f"Address {address} - ReadMainBatteryVoltage: {battery}")
+        one_connected = True
+    if connected1:
         print("Connected to /dev/serial1.")
-        print(roboclaw1.ReadVersion(address))
-        print(roboclaw1.ReadEncM1(address))
-    else:
+        print(f"Address: {address}")
+        print("ReadVersion:", roboclaw1.ReadVersion(address))
+        print("ReadEncM1:", roboclaw1.ReadEncM1(address))
+        battery = roboclaw1.ReadMainBatteryVoltage(address)
+        print(f"Address {address} - ReadMainBatteryVoltage: {battery}")
+        one_connected = True
+    if not one_connected:
         print("Could not open comport /dev/serial0 or /dev/serial1, make sure it has the correct permissions and is available")


### PR DESCRIPTION
It seems that sometimes roboclaw.Open() will return a success even if it doesn't seem to be able to actually read any data from the roboclaw. I had this experience and one other person did in the Slack channel. I propose this code change so that we try both serial connections.