### PR TITLE
Adding a fix for Issue #195 by including a requirements.txt to manage external dependencies.

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,3 @@
-adafruit-circuitpython-servokit
-adafruit-circuitpython-ina260
-RPi.GPIO
+adafruit-circuitpython-servokit==1.3.19
+adafruit-circuitpython-ina260==1.3.17
+RPi.GPIO==0.7.1

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+adafruit-circuitpython-servokit
+adafruit-circuitpython-ina260
+RPi.GPIO


### PR DESCRIPTION
Adding `requirements.txt` to manage the following external dependencies 

1. https://pypi.org/project/RPi.GPIO/#history
2. https://pypi.org/project/adafruit-circuitpython-servokit/#history
3. https://pypi.org/project/adafruit-circuitpython-ina260/#history