### PR TITLE
fix drive_left_back ticks_per_rev typo

### DIFF
--- a/ROS/osr_bringup/config/roboclaw_params.yaml
+++ b/ROS/osr_bringup/config/roboclaw_params.yaml
@@ -24,7 +24,7 @@ roboclaw_wrapper:
       drive_left_back:
         address: 129
         channel: M2
-        ticks_per_rev: 4288
+        ticks_per_rev: 28
         gear_ratio: 26.9
       drive_right_back:
         address: 129


### PR DESCRIPTION
@igillespie I was racking my brain to figure out why my left back wheel was spinning super hard, even in duty mode. Small typo you [introduced in your last PR](https://github.com/nasa-jpl/osr-rover-code/commit/af230f92116c621f5dbe29d545e19fe9c62f3600). :) Since this is a hotfix with obvious consequences, I will merge this in right away.

@abust005 