### PR TITLE
Replaced depricated ForwardM1 command with DutyM1 to stop motors

### DIFF
--- a/ROS/osr_control/osr_control/roboclaw_wrapper.py
+++ b/ROS/osr_control/osr_control/roboclaw_wrapper.py
@@ -445,8 +445,8 @@ class RoboclawWrapper(Node):
     def stop_motors(self):
         """Stops all motors on Rover"""
         for i in range(3):
-            self.rc.ForwardM1(self.address[i], 0)
-            self.rc.ForwardM2(self.address[i], 0)
+            self.rc.DutyM1(self.address[i], 0)
+            self.rc.DutyM2(self.address[i], 0)
 
     def read_errors(self):
         """Checks error status of each motor controller, returns 0 if no errors reported"""

--- a/scripts/roboclaw_movemotor.py
+++ b/scripts/roboclaw_movemotor.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
         sleep(0.5)
     sleep(1)
     # stop motor
-    rc.ForwardM1(address, 0)
+    rc.DutyM1(address, 0)
 
     print("M2:")
     # Move M2
@@ -89,4 +89,4 @@ if __name__ == "__main__":
         sleep(0.5)
     sleep(1)
     # stop motor
-    rc.ForwardM2(address, 0)
+    rc.DutyM2(address, 0)


### PR DESCRIPTION
When launching code while running Roboclaw 4.3.6 (currently earliest version confirmed to not work), the code will hang for ~36 seconds on Roboclaw initialization before finishing bringup. This is due to the Roboclaw library function `ForwardM1` being [deprecated and not sufficiently supported in the newest versions](https://www.basicmicro.com/crm.asp?mk=eiebbuvbgb-6532). This library function is called in the `roboclaw_wrapper.py` file in the `stop_motors()` function to halt all the motors. This causes a hangup since the function times out after the roboclaws fail to send an acknowledge byte. [Roboclaw support advised](https://www.basicmicro.com/crm.asp?mk=lnjqrpgpor-6483) to replace the function call with a currently supported function. I chose to replace it with `DutyM1` which immediately sets all PWM values to 0 to stop the motors with minimal delay. Furthermore, this function will work even if the user has not appropriately calibrated their motor speeds.