### PR TITLE
Add support for PWM LEDs

### DIFF
--- a/ROS/osr_control/osr_control/joy_extras.py
+++ b/ROS/osr_control/osr_control/joy_extras.py
@@ -15,13 +15,18 @@ class JoyButtonSubscriber(Node):
         self.declare_parameter('duty_button_index', 0)  # Default button index is 0
         self.duty_button_index = self.get_parameter('duty_button_index').value
         self.last_duty_mode_value = False
+        self.front_led_on = False
         self.last_received_time = None        
         self.cb_group = ReentrantCallbackGroup()
         self.roboclaw_node_set_param_client = self.create_client(SetParameters, '/roboclaw_wrapper/set_parameters', 
                                                                  callback_group=self.cb_group)
         while not self.roboclaw_node_set_param_client.wait_for_service(timeout_sec=5.0):
             self.log.info('Service /roboclaw_wrapper/set_parameters not available, waiting again...', skip_first=True)
-        
+        self.rover_node_set_param_client = self.create_client(SetParameters, '/rover/set_parameters', 
+                                                            callback_group=self.cb_group)
+        while not self.rover_node_set_param_client.wait_for_service(timeout_sec=5.0):
+            self.log.info('Service /rover/set_parameters not available, waiting again...', skip_first=True)
+
         self.subscription = self.create_subscription(
             Joy,
             'joy',
@@ -45,6 +50,18 @@ class JoyButtonSubscriber(Node):
             self.last_duty_mode_value = not self.last_duty_mode_value
             await self.set_parameter_value_on_other_node(self.roboclaw_node_set_param_client, param)
             self.last_received_time = current_time
+
+        led_switch_on = msg.axes[1] > 0.3
+        if led_switch_on and not self.front_led_on:
+            self.log.info("Turning front LEDs on")
+            param = Parameter(name="leds_enabled", value=True).to_parameter_msg()
+            await self.set_parameter_value_on_other_node(self.rover_node_set_param_client, param)
+            self.front_led_on = True
+        elif not led_switch_on and self.front_led_on:
+            self.log.info("Turning front LEDs off")
+            param = Parameter(name="leds_enabled", value=False).to_parameter_msg()
+            await self.set_parameter_value_on_other_node(self.rover_node_set_param_client, param)
+            self.front_led_on = False
 
     async def set_parameter_value_on_other_node(self, node_set_param_client, param):
         request = SetParameters.Request()

--- a/ROS/osr_control/osr_control/led_control.py
+++ b/ROS/osr_control/osr_control/led_control.py
@@ -1,0 +1,68 @@
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile
+from std_msgs.msg import UInt8MultiArray
+from adafruit_servokit import ServoKit
+
+
+class LEDControlNode(Node):
+    """
+    Node to control the intensity of two LEDs connected to channels 4 and 5 of the PCA9685.
+    The intensity is controlled by publishing two percentages (0-100) to the topic '/led_intensity'.
+    """
+
+    def __init__(self):
+        super().__init__('led_control_node')
+        self.log = self.get_logger()
+        self.log.info("Initializing LED Control Node")
+
+        # Initialize I2C and PCA9685
+        self.kit = ServoKit(channels=16)
+
+        # LED channels
+        self.led_channels = [4, 5]
+
+        # Create subscription to control LED intensity
+        qos_profile = QoSProfile(depth=10)
+        self.subscription = self.create_subscription(
+            UInt8MultiArray,
+            '/led_intensity',
+            self.led_intensity_callback,
+            qos_profile
+        )
+
+    def led_intensity_callback(self, msg: UInt8MultiArray):
+        """
+        Callback to set the intensity of the LEDs based on the received message.
+        The message should contain two float values (0-100) representing the intensity percentages.
+        """
+        if len(msg.data) != 2:
+            self.log.error("Received message does not contain exactly two values. Ignoring.")
+            return
+
+        for i, intensity in enumerate(msg.data):
+            if not intensity <= 100:
+                self.log.error(f"Invalid intensity value {intensity}. Must be between 0 and 100.")
+                return
+
+            # Convert percentage to an angle
+            angle = int((intensity / 100.0) * 180)
+            self.kit.servo[self.led_channels[i]].angle = angle
+            self.log.debug(f"Set LED on channel {self.led_channels[i]} to {intensity}% intensity.")
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = LEDControlNode()
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/ROS/osr_control/osr_control/rover.py
+++ b/ROS/osr_control/osr_control/rover.py
@@ -3,13 +3,14 @@ from functools import partial
 
 import rclpy
 from rclpy.parameter import Parameter
+from rclpy.parameter_event_handler import ParameterEventHandler
 from rclpy.node import Node
 import tf2_ros
 
 from sensor_msgs.msg import JointState
 from geometry_msgs.msg import Twist, TwistWithCovariance, TransformStamped
 from nav_msgs.msg import Odometry
-from std_msgs.msg import Float64
+from std_msgs.msg import Float64, UInt8MultiArray
 from osr_interfaces.msg import CommandDrive, CommandCorner
 
 
@@ -32,13 +33,23 @@ class Rover(Node):
                 ('rover_dimensions.wheel_radius', Parameter.Type.DOUBLE),
                 ('drive_no_load_rpm', Parameter.Type.DOUBLE),
                 ('enable_odometry', Parameter.Type.BOOL),
-                ('publish_transform', Parameter.Type.BOOL)
+                ('publish_transform', Parameter.Type.BOOL),
+                ('leds_enabled', False)
             ]
         )
         self.d1 = self.get_parameter('rover_dimensions.d1').get_parameter_value().double_value
         self.d2 = self.get_parameter('rover_dimensions.d2').get_parameter_value().double_value
         self.d3 = self.get_parameter('rover_dimensions.d3').get_parameter_value().double_value
         self.d4 = self.get_parameter('rover_dimensions.d4').get_parameter_value().double_value
+
+        # add a dynamic parameter callback handler
+        self.handler = ParameterEventHandler(self)
+
+        self.callback_handle = self.handler.add_parameter_callback(
+            parameter_name="leds_enabled",
+            node_name="rover",
+            callback=self.parameter_change_cb,
+        )
 
         self.min_radius = 0.45  # [m]
         self.max_radius = 6.4  # [m]
@@ -77,6 +88,14 @@ class Rover(Node):
 
         self.corner_cmd_pub = self.create_publisher(CommandCorner, "/cmd_corner", 1)
         self.drive_cmd_pub = self.create_publisher(CommandDrive, "/cmd_drive", 1)
+        self.leds_pub = self.create_publisher(UInt8MultiArray, "/led_intensity", 1)
+
+    def parameter_change_cb(self, p: rclpy.parameter.Parameter) -> None:
+        self.get_logger().info(f"Received an update to parameter: {p.name}: {rclpy.parameter.parameter_value_to_python(p.value)}")
+        if p.name == "leds_enabled":
+            self.leds_enabled = p.value
+            msg = UInt8MultiArray(data=[100, 100]) if p.value.bool_value else UInt8MultiArray(data=[0, 0])
+            self.leds_pub.publish(msg)
 
     def cmd_cb(self, twist_msg, intuitive=False):
         """

--- a/ROS/osr_control/setup.py
+++ b/ROS/osr_control/setup.py
@@ -28,7 +28,8 @@ setup(
             'roboclaw_wrapper = osr_control.roboclaw_wrapper:main',
             'servo_control = osr_control.servo_control:main',
             'ina260 = osr_control.ina_260_pub:main',
-            'joy_extras = osr_control.joy_extras:main'
+            'joy_extras = osr_control.joy_extras:main',
+            'led_control = osr_control.led_control:main',
         ],
     },
 )


### PR DESCRIPTION
Simple control node for LEDs. Works with the servo_control node running concurrently.

- [ ] make number of LEDs expandable by parametrizing `led_channels`