### PR TITLE
Add user to Input Group to enable joystick without changing permissions every time

### DIFF
--- a/setup/rpi.md
+++ b/setup/rpi.md
@@ -144,13 +144,14 @@ sudo cp ~/osr_ws/src/osr-rover-code/config/* /etc/udev/rules.d/
 sudo udevadm control --reload-rules && sudo udevadm trigger
 ```
 
-### Add user to tty and dialout groups
+### Add user to system groups
 
-Finally, add the user to the `tty` and `dialout` groups on the raspberry pi:
+Finally, add the user to the `tty` `dialout`, and `input` groups on the raspberry pi:
 
 ```bash
 sudo adduser $USER tty
 sudo adduser $USER dialout
+sudo adduser $USER input
 ```
 
 You might have to create the dialout group if it doesn't already exist with `groupadd dialout`.


### PR DESCRIPTION
The Joystick is not read by the user by default since the input file does not have read permissions for other users. Adding the user to the Input group gives them read access to the joystick inputs.

closes #131 